### PR TITLE
Add support for transforming PathIndex into string.

### DIFF
--- a/Sources/PathIndexable/PathIndexable.swift
+++ b/Sources/PathIndexable/PathIndexable.swift
@@ -63,6 +63,11 @@ public protocol PathIndex {
          - returns: an empty structure that can be set by Self
     */
     func makeEmptyStructure<T: PathIndexable>() -> T
+    
+    /**
+        - returns: a string representation of the PathIndex
+     */
+    var string: String { get }
 }
 
 extension Int: PathIndex {
@@ -102,6 +107,10 @@ extension Int: PathIndex {
 
     public func makeEmptyStructure<T: PathIndexable>() -> T {
         return T([])
+    }
+    
+    public var string: String {
+        return "\(self)"
     }
 }
 
@@ -150,5 +159,9 @@ extension String: PathIndex {
 
     public func makeEmptyStructure<T: PathIndexable>() -> T {
         return T([:])
+    }
+    
+    public var string: String {
+        return self
     }
 }


### PR DESCRIPTION
Add support for transforming a `PathIndex` into a string.

In conjunction with : https://github.com/vapor/node/pull/33